### PR TITLE
Make uppercase CPP_DUMP() deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,15 +305,11 @@ The style of indents of the Container, Set and Map categories (See [Supported ty
 
 ```cpp
 /**
- * Output string representations of expression(s) and result(s) to std::clog.
- * This is an alias of CPP_DUMP(expressions...).
+ * Print string representations of expressions and results to std::clog or other configurable outputs.
+ * If you want to change the output, define an explicit specialization of cpp_dump::write_log().
+ * This macro uses cpp_dump::export_var() internally.
  */
 #define cpp_dump(expressions...)
-
-/**
- * Output string representations of expression(s) and result(s) to std::clog.
- */
-#define CPP_DUMP(expressions...)
 
 /**
  * Make export_var() support type T.

--- a/dump.hpp
+++ b/dump.hpp
@@ -27,7 +27,7 @@
  * Print string representations of expression(s) and result(s) to std::clog.
  * This macro uses cpp_dump::export_var() internally.
  */
-#define CPP_DUMP(...)                                                                              \
+#define cpp_dump(...)                                                                              \
   cpp_dump::_detail::cpp_dump_macro<_p_CPP_DUMP_VA_SIZE(__VA_ARGS__)>(                             \
       {__FILE__, __LINE__, __func__},                                                              \
       {_p_CPP_DUMP_EXPAND_VA(_p_CPP_DUMP_EXPAND_FOR_CPP_DUMP, __VA_ARGS__)},                       \
@@ -35,11 +35,10 @@
   )
 
 /**
- * Print string representations of expression(s) and result(s) to std::clog.
- * This macro uses cpp_dump::export_var() internally.
- * This is an alias of CPP_DUMP(...).
+ * This is deprecated.
+ * Use cpp_dump() instead.
  */
-#define cpp_dump(...) CPP_DUMP(__VA_ARGS__)
+#define CPP_DUMP(...) cpp_dump(__VA_ARGS__)
 
 namespace cpp_dump {
 

--- a/dump.hpp
+++ b/dump.hpp
@@ -24,7 +24,9 @@
 #define _p_CPP_DUMP_EXPAND_FOR_CPP_DUMP(expr) #expr
 
 /**
- * Print string representations of expression(s) and result(s) to std::clog.
+ * Print string representations of expressions and results to std::clog or other configurable
+ * outputs.
+ * If you want to change the output, define an explicit specialization of cpp_dump::write_log().
  * This macro uses cpp_dump::export_var() internally.
  */
 #define cpp_dump(...)                                                                              \


### PR DESCRIPTION
See #4 for details.